### PR TITLE
issue #7 Hash based execution plan ID

### DIFF
--- a/src/spline_agent/constants.py
+++ b/src/spline_agent/constants.py
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 import importlib.metadata
+from uuid import UUID
 
 import spline_agent
 from spline_agent.lineage_model import NameAndVersion
@@ -21,3 +22,5 @@ AGENT_INFO = NameAndVersion(
     name='spline-python-agent',
     version=importlib.metadata.version(spline_agent.__name__)
 )
+
+EXECUTION_PLAN_NAMESPACE: UUID = UUID('475196d0-16ca-4cba-aec7-c9f2ddd9326c')

--- a/src/spline_agent/harvester.py
+++ b/src/spline_agent/harvester.py
@@ -17,9 +17,10 @@ import sys
 import uuid
 from typing import Callable
 
-from spline_agent.constants import AGENT_INFO
+from spline_agent.constants import AGENT_INFO, EXECUTION_PLAN_NAMESPACE
 from spline_agent.context import LineageTrackingContext, WriteMode
 from spline_agent.exceptions import LineageContextIncompleteError
+from spline_agent.json_serde import to_json_str
 from spline_agent.lineage_model import *
 from spline_agent.utils import current_time
 
@@ -62,12 +63,14 @@ def harvest_lineage(
     )
 
     plan = ExecutionPlan(
-        id=uuid.uuid4(),
+        id=None,  # the value assigned below as it needs to be calculated from the object hash
         name=ctx.name,
         operations=operations,
         systemInfo=ctx.system_info,
         agentInfo=AGENT_INFO,
     )
+
+    plan.id = uuid.uuid5(EXECUTION_PLAN_NAMESPACE, to_json_str(plan))
 
     event = ExecutionEvent(
         planId=plan.id,

--- a/src/spline_agent/lineage_model.py
+++ b/src/spline_agent/lineage_model.py
@@ -65,7 +65,7 @@ class Operations:
 
 @dataclass
 class ExecutionPlan:
-    id: UUID
+    id: Optional[UUID]
     name: Optional[str]
     systemInfo: NameAndVersion
     agentInfo: NameAndVersion


### PR DESCRIPTION
fixes #7

Replace execution plan ID type from UUID v4 with UUID v5 (hash based), to deduplicate identical execution plans.