### PR TITLE
Feature/spline python agent 21 segregate decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,28 +16,30 @@ So that the lineage tracking process would be as seamless and non-intrusive to t
 Example:
 
 ```python
-# Define a user function
-def my_data_transform(output_source, input_source_1, input_source_2):
+import spline_agent
+from spline_agent.enums import WriteMode
+
+
+# Decorate a function you want to track with as follows
+@spline_agent.track_lineage()
+@spline_agent.inputs('{input_source_1}', '{input_source_2}')
+@spline_agent.output('{output_source}', WriteMode.APPEND)
+def my_awesome_function(output_source, input_source_1, input_source_2):
     print("read from input source")
     print("do some business logic")
     print("write into the output")
-  
-# Define data sources
-input_source_1 = S3DataSource(...)
-input_source_2 = FileDataSource(...)
-output_source = HDFSDataSource("my.parquet")
 
-# Use the SplineAgent to execute the user function
-agent = SplineAgent()
-agent.execute(my_data_transform, output_source, input_source_1, input_source_2)
 
-# later in another Python program that consumes data from the "my.parquet"... 
-
-input_source = HDFSDataSource("my.parquet")
-agent.execute(my_another_function, my_another_output_source, input_source)
-
-# The lineage would be recorded and the dependency between both runs would be inferred automatically.
+# Execute the target function as normal
+my_awesome_function("some_url_1", "some_url_2", "some_url_3")
 ```
+
+The `inputs()` and `output()` decorators could be places on any other
+function that is called (also transitively) from the `my_awesome_function`.
+The data source can be represented as a URL string t the source,
+or the string containing the Spline Expression (SpEL) - currently ir only
+supports the format `"{func_parameter_name}"` (e.r. `"{abc}"` would mean -
+take the value from the `abc` parameter of the decorated function).
 
 # Building
 

--- a/examples/simple_example.py
+++ b/examples/simple_example.py
@@ -13,20 +13,18 @@
 #  limitations under the License.
 
 import logging
+import os
 
 import spline_agent
-from spline_agent import get_tracking_context
 from spline_agent.enums import WriteMode
 from spline_agent.lineage_model import NameAndVersion
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=logging.getLevelName(os.environ.get('LOG_LEVEL') or 'INFO'))
 
 
 @spline_agent.track_lineage(
     name='My awesome python app',
-    inputs=('{data_url_1}', '{data_url_2}'),
-    output='{result_url}',
     system_info=NameAndVersion(name='name of my data processing engine', version='0.0.0'),
 )
 def main(data_url_1: str, data_url_2: str, result_url: str):
@@ -44,16 +42,17 @@ def main(data_url_1: str, data_url_2: str, result_url: str):
     result_data = _do_some_magic(data_1, data_2)
 
     _dummy_write(result_url, result_data)
-    get_tracking_context().write_mode = WriteMode.OVERWRITE
 
     logger.info('DONE')
 
 
+@spline_agent.inputs('{url}')
 def _dummy_read(url: str):
     logger.info(f'reading from {url} ... OK')
     return "dummy data"
 
 
+@spline_agent.output('{url}', WriteMode.OVERWRITE)
 def _dummy_write(url: str, data):
     logger.info(f'writing [{data}] to {url} ... OK')
     pass

--- a/examples/spline.yaml
+++ b/examples/spline.yaml
@@ -1,1 +1,6 @@
-spline.lineage_dispatcher.type: console
+spline:
+  lineage_dispatcher:
+#    type: http
+    http:
+      content_type: 'application/vnd.absa.spline.producer.v1.1+json'
+#      base_url: 'http://localhost:8080/producer'

--- a/src/spline_agent/constants.py
+++ b/src/spline_agent/constants.py
@@ -14,6 +14,7 @@
 
 import importlib.metadata
 import os
+import platform
 from uuid import UUID
 
 import spline_agent
@@ -22,6 +23,11 @@ from spline_agent.lineage_model import NameAndVersion
 AGENT_INFO = NameAndVersion(
     name='spline-python-agent',
     version=importlib.metadata.version(spline_agent.__name__)
+)
+
+DEFAULT_SYSTEM_INFO = NameAndVersion(
+    name=platform.python_implementation(),
+    version=platform.python_version()
 )
 
 EXECUTION_PLAN_NAMESPACE: UUID = UUID('475196d0-16ca-4cba-aec7-c9f2ddd9326c')

--- a/src/spline_agent/context.py
+++ b/src/spline_agent/context.py
@@ -84,7 +84,7 @@ _context_holder: ContextVar[LineageTrackingContext] = ContextVar('context')
 
 
 def get_tracking_context() -> LineageTrackingContext:
-    from .decorator import track_lineage
+    from spline_agent.decorators.track_lineage_decorator import track_lineage
 
     ctx = _context_holder.get(None)
     if ctx is None:

--- a/src/spline_agent/decorators/__init__.py
+++ b/src/spline_agent/decorators/__init__.py
@@ -11,9 +11,3 @@
 #  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
-
-from spline_agent.datasources import DataSource
-from spline_agent.decorators.io_decorators import inputs, output
-from spline_agent.decorators.model import DsParamExpr
-from spline_agent.decorators.track_lineage_decorator import track_lineage
-from .context import get_tracking_context

--- a/src/spline_agent/decorators/io_decorators.py
+++ b/src/spline_agent/decorators/io_decorators.py
@@ -1,0 +1,59 @@
+#  Copyright 2023 ABSA Group Limited
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+from __future__ import annotations
+
+import logging
+from functools import wraps
+from typing import Callable
+
+from .model import DsParamExpr, DataSource
+from ..context import get_tracking_context, LineageTrackingContext
+from ..decorators.spel_evaluator import SpELEvaluator
+from ..enums import WriteMode
+
+logger = logging.getLogger(__name__)
+
+
+def inputs(*exprs: DsParamExpr):
+    def handler(ctx: LineageTrackingContext, ds: DataSource):
+        ctx.add_input(ds)
+
+    return lambda func: _decor(func, handler, *exprs)
+
+
+def output(expr: DsParamExpr, write_mode: WriteMode):
+    def handler(ctx: LineageTrackingContext, ds: DataSource):
+        ctx.output = ds
+        ctx.write_mode = write_mode
+
+    return lambda func: _decor(func, handler, expr)
+
+
+def _decor(
+        func: Callable,
+        handler: Callable[[LineageTrackingContext, DataSource], None],
+        *ds_exprs: DsParamExpr
+):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        ctx = get_tracking_context()
+        spel_evaluator = SpELEvaluator(func, args, kwargs)
+        for expr in ds_exprs:
+            ds = spel_evaluator.eval_as_data_source(expr)
+            handler(ctx, ds)
+
+        return func(*args, **kwargs)
+
+    return wrapper

--- a/src/spline_agent/decorators/model.py
+++ b/src/spline_agent/decorators/model.py
@@ -12,8 +12,9 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-from spline_agent.datasources import DataSource
-from spline_agent.decorators.io_decorators import inputs, output
-from spline_agent.decorators.model import DsParamExpr
-from spline_agent.decorators.track_lineage_decorator import track_lineage
-from .context import get_tracking_context
+from typing import Union
+
+from ..datasources import DataSource
+
+SpELExpr = str
+DsParamExpr = Union[SpELExpr, DataSource]

--- a/src/spline_agent/decorators/spel_evaluator.py
+++ b/src/spline_agent/decorators/spel_evaluator.py
@@ -1,0 +1,52 @@
+#  Copyright 2023 ABSA Group Limited
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+import inspect
+from typing import Callable, Mapping, Any
+from urllib.parse import urlparse
+
+from spline_agent.datasources import DataSource
+from spline_agent.decorators.model import SpELExpr, DsParamExpr
+
+
+class SpELEvaluator:
+    def __init__(self, func: Callable, args, kwargs):
+        # inspect the 'func' signature and collect the parameter names
+        sig: inspect.Signature = inspect.signature(func)
+        params: Mapping[str, inspect.Parameter] = sig.parameters
+
+        # create a combined dictionary of all arguments passed to target function
+        self.__bindings = {**{key: arg for key, arg in zip(params, args)}, **kwargs}
+
+    def eval(self, expr: SpELExpr) -> Any:
+        if type(expr) is not str:
+            raise TypeError(f'SpEL expression has to be string, but was {type(expr)}')
+        if expr.startswith('{') and expr.endswith('}') and (expr[1:-1]).isidentifier():
+            key = expr[1:-1]
+            val = self.__bindings[key]
+            return self.eval(val) if type(val) is str else val
+        return expr
+
+    def eval_as_data_source(self, expr: DsParamExpr) -> DataSource:
+        if isinstance(expr, DataSource):
+            return expr
+
+        if type(expr) is str:
+            val = self.eval(expr)
+            if isinstance(val, DataSource):
+                return val
+            if type(val) is str and urlparse(val):
+                return DataSource(val)
+
+        raise ValueError(f'{expr} should be a DataSource, URL string, or a parameter binding expression like {{name}}')

--- a/src/spline_agent/lineage_model.py
+++ b/src/spline_agent/lineage_model.py
@@ -67,9 +67,10 @@ class Operations:
 class ExecutionPlan:
     id: Optional[UUID]
     name: Optional[str]
-    systemInfo: NameAndVersion
-    agentInfo: NameAndVersion
     operations: Operations
+    agentInfo: NameAndVersion
+    systemInfo: NameAndVersion
+    extraInfo: Mapping[str, Any]
 
 
 @dataclass
@@ -78,6 +79,7 @@ class ExecutionEvent:
     timestamp: Timestamp
     durationNs: Optional[DurationNs]
     error: Optional[Any]
+    extra: Mapping[str, Any]
 
 
 @dataclass


### PR DESCRIPTION
closes #21 

Extracted inputs and output mapping from the `@track_lineage(...)` to the two new  decorators: `input()` and `output()` respectively